### PR TITLE
jspm Node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,12 @@
       "url": "http://netflix.com"
     }
   ],
+  "jspm": {
+    "map": {
+      "./constants.json": {
+        "node": "@node/constants"
+      }
+    }
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR includes the necessary jspm configuration for this package to work both client and server in the coming jspm 0.17 release.

I completely understand if you'd rather not support this here, but it will simplify user configuration locally having it in one place. There is no maintenance burden either as I would continue to maintain this personally.

Just let me know if you have any questions at all, and thanks for considering.
